### PR TITLE
Added collection initialization for Lists, Sets, Maps, and Arrays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ For example, given the following class:
         private final String firstName;
         private final String lastName;
         private final int age;
+        private final List<Person> children = new ArrayList<Person>();
 
-        public Person(String firstName, String lastName, int age) {
+        public Person(String firstName, String lastName, int age, List<Person> children) {
             this.firstName = firstName;
             this.lastName = lastName;
             this.age = age;
+            this.children = new ArrayList<Person>(children);
         }
 
         ...
@@ -36,6 +38,7 @@ The builder that is produced would look like this:
         private String firstName;
         private String lastName;
         private int age;
+        private List<Person> children = new ArrayList<Person>();
 
         public static PersonBuilder builder() {
             return new PersonBuilder();
@@ -56,8 +59,13 @@ The builder that is produced would look like this:
             return this;
         }
 
+        public PersonBuilder withChildren(List<Person> children) {
+            this.children = children;
+            return this;
+        }
+
         public Person build() {
-            return new Person(firstName, lastName, age);
+            return new Person(firstName, lastName, age, children);
         }
     }
 
@@ -171,7 +179,7 @@ for just this purpose:
         }
     }
 
-You now have way to easlily create instances of a `Person` in the desired married and employed state:
+You now have way to easily create instances of a `Person` in the desired married and employed state:
 
     Person person = PersonPrototypes.aMarriedAndEmployedPerson().build();
 
@@ -191,7 +199,7 @@ Thanks to [Jorge Hidalgo](http://deors.wordpress.com/) for helping me get the ba
 
 ## Footnotes
 
-1. The benefits of immutablity have been 
+1. The benefits of immutablity have been
 [well covered elsewhere](https://www.google.com/search?q=favor+java+immutability).
 
 2. Explicitly checking each parameter in an if block and conditionally throwing an exception can get quite noisy.

--- a/processor/src/test/java/com/twoqubed/bob/processor/InternalBuilderWriterTest.java
+++ b/processor/src/test/java/com/twoqubed/bob/processor/InternalBuilderWriterTest.java
@@ -20,6 +20,13 @@ public class InternalBuilderWriterTest {
         metadata.packageName = "com.twoqubed.bob.processor.generated";
         metadata.addConstructorParam(new ConstructorParam("bar", "java.lang.String"));
         metadata.addConstructorParam(new ConstructorParam("baz", "java.lang.String"));
+        metadata.addConstructorParam(new ConstructorParam("qux", "java.lang.Boolean"));
+        metadata.addConstructorParam(new ConstructorParam("norf", "boolean"));
+        metadata.addConstructorParam(new ConstructorParam("list", "java.util.List<java.lang.String>"));
+        metadata.addConstructorParam(new ConstructorParam("set", "java.util.Set<java.lang.String>"));
+        metadata.addConstructorParam(new ConstructorParam("map", "java.util.Map<java.lang.String, java.lang.Integer>"));
+        metadata.addConstructorParam(new ConstructorParam("intArray", "int[]"));
+        metadata.addConstructorParam(new ConstructorParam("objectArray", "java.lang.Object[]"));
 
         InternalBuilderWriter writer = new InternalBuilderWriter();
         StringWriter actual = new StringWriter();

--- a/processor/src/test/resources/com/twoqubed/bob/processor/generated/FooBuilder.java
+++ b/processor/src/test/resources/com/twoqubed/bob/processor/generated/FooBuilder.java
@@ -4,6 +4,13 @@ public class FooBuilder {
 
     private java.lang.String bar;
     private java.lang.String baz;
+    private java.lang.Boolean qux;
+    private boolean norf;
+    private java.util.List<java.lang.String> list = new java.util.ArrayList<java.lang.String>();
+    private java.util.Set<java.lang.String> set = new java.util.HashSet<java.lang.String>();
+    private java.util.Map<java.lang.String, java.lang.Integer> map = new java.util.HashMap<java.lang.String, java.lang.Integer>();
+    private int[] intArray = new int[0];
+    private java.lang.Object[] objectArray = new java.lang.Object[0];
 
     public static FooBuilder builder() {
         return new FooBuilder();
@@ -19,10 +26,52 @@ public class FooBuilder {
         return this;
     }
 
+    public FooBuilder withQux(java.lang.Boolean qux) {
+        this.qux = qux;
+        return this;
+    }
+
+    public FooBuilder withNorf(boolean norf) {
+        this.norf = norf;
+        return this;
+    }
+
+    public FooBuilder withList(java.util.List<java.lang.String> list) {
+        this.list = list;
+        return this;
+    }
+
+    public FooBuilder withSet(java.util.Set<java.lang.String> set) {
+        this.set = set;
+        return this;
+    }
+
+    public FooBuilder withMap(java.util.Map<java.lang.String, java.lang.Integer> map) {
+        this.map = map;
+        return this;
+    }
+
+    public FooBuilder withIntArray(int[] intArray) {
+        this.intArray = intArray;
+        return this;
+    }
+
+    public FooBuilder withObjectArray(java.lang.Object[] objectArray) {
+        this.objectArray = objectArray;
+        return this;
+    }
+
     public Foo build() {
         return new Foo(
                 bar,
-                baz
+                baz,
+                qux,
+                norf,
+                list,
+                set,
+                map,
+                intArray,
+                objectArray
         );
     }
 }

--- a/sample/src/test/java/com/twoqubed/bob/processor/ObjectsTest.java
+++ b/sample/src/test/java/com/twoqubed/bob/processor/ObjectsTest.java
@@ -33,4 +33,17 @@ public class ObjectsTest {
         assertEquals(strings, objectsSample.getListOfStrings());
     }
 
+    @Test
+    public void buildsWithoutListOfStrings() {
+        Date now = new Date();
+
+        ObjectsSample objectsSample = ObjectsSampleBuilder.builder()
+                .withAString("foo")
+                .withADate(now)
+                .build();
+
+        assertEquals("foo", objectsSample.getAString());
+        assertEquals(now, objectsSample.getADate());
+        assertEquals(0, objectsSample.getAListOfStrings().size());
+    }
 }


### PR DESCRIPTION
#12 This is necessary for defensive copies of collections in the domain objects.  For example, with the following:

```
@Built
    public Person {
        private final String firstName;
        private final String lastName;
        private final int age;
        private final List<Person> children = new ArrayList<Person>();

        public Person(String firstName, String lastName, int age, List<Person> children) {
            this.firstName = firstName;
            this.lastName = lastName;
            this.age = age;
            this.children = new ArrayList<Person>(children);
        }

        ...
    }
```

If I created a new person without children:

```
Person dad = PersonBuilder.builder()
                .withFirstName("Ward")
                .withLastName("Cleaver")
                .withAge(45)
                .build();
```

The above would throw a NullPointerException because the children list is null.  This change will initialize the children list in the builder with an empty ArrayList.
